### PR TITLE
PXMAP-219: Support for "default" binary operator

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -266,6 +266,10 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
   def visitBinaryOp(offset: Int, lhs: Expr, op: BinaryOp.Op, rhs: Expr)
                    (implicit scope: ValScope, fileScope: FileScope) = {
     op match {
+      case Expr.BinaryOp.`default` =>
+        try visitExpr(lhs)
+        catch { case e: Error => visitExpr(rhs) }
+
       // && and || are handled specially because unlike the other operators,
       // these short-circuit during evaluation in some cases when the LHS is known.
       case Expr.BinaryOp.`&&` | Expr.BinaryOp.`||` =>

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -92,6 +92,7 @@ object Expr{
     case object `|` extends Op
     case object `&&` extends Op
     case object `||` extends Op
+    case object `default` extends Op
   }
   case class AssertExpr(offset: Int, asserted: Member.AssertStmt, returned: Expr) extends Expr
   case class LocalExpr(offset: Int, bindings: Seq[Bind], returned: Expr) extends Expr

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -13,6 +13,7 @@ import scala.annotation.switch
   */
 object Parser{
   val precedenceTable = Seq(
+    Seq("default"),
     Seq("*", "/", "%"),
     Seq("+", "-"),
     Seq("<<", ">>"),
@@ -173,6 +174,7 @@ object Parser{
                   case "|" => Expr.BinaryOp.`|`
                   case "&&" => Expr.BinaryOp.`&&`
                   case "||" => Expr.BinaryOp.`||`
+                  case "default" => Expr.BinaryOp.`default`
                 }
                 result = Expr.BinaryOp(offset, result, op1, rhs)
                 true
@@ -335,7 +337,7 @@ object Parser{
   def binaryop[_: P] = P(
     StringIn(
       "<<", ">>", "<=", ">=", "in", "==", "!=", "&&", "||",
-      "*", "/", "%", "+", "-", "<", ">", "&", "^", "|"
+      "*", "/", "%", "+", "-", "<", ">", "&", "^", "|", "default"
     )
 
   ).!

--- a/sjsonnet/test/src/sjsonnet/DefaultExprTests.scala
+++ b/sjsonnet/test/src/sjsonnet/DefaultExprTests.scala
@@ -23,6 +23,7 @@ object DefaultExprTests extends TestSuite{
       eval("local obj = {}; (1 + obj.nonExistent) default 2").value ==> 2
       eval("local obj = { a: 1 }; obj.nonExistent default obj.a default obj.anotherNonExistent").value ==> 1
       eval("local obj = { a: 1 }; obj.nonExistent default obj.anotherNonExistent default obj.a").value ==> 1
+      eval("local obj = { a: 1 }; (obj.nonExistent + 1) default 2").value ==> 2
     }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/DefaultExprTests.scala
+++ b/sjsonnet/test/src/sjsonnet/DefaultExprTests.scala
@@ -1,0 +1,28 @@
+package sjsonnet
+
+import utest._
+
+object DefaultExprTests extends TestSuite{
+  def eval(s: String) = {
+    new Interpreter(
+      SjsonnetMain.createParseCache(),
+      Map(),
+      Map(),
+      DummyPath(),
+      (_, _) => None
+    ).interpret(s, DummyPath("(memory)")) match{
+      case Right(x) => x
+      case Left(e) => throw new Exception(e)
+    }
+  }
+  def tests = Tests{
+    test("defaultExpr") {
+      eval("local obj = {}; obj.nonExistent default \"HelloWorld\" ").value.toString() ==> "HelloWorld"
+      eval("local obj = {}; obj.nonExistent default false || true ").value ==> true
+      eval("local obj = {}; 1 + obj.nonExistent default 2").value ==> 3
+      eval("local obj = {}; (1 + obj.nonExistent) default 2").value ==> 2
+      eval("local obj = { a: 1 }; obj.nonExistent default obj.a default obj.anotherNonExistent").value ==> 1
+      eval("local obj = { a: 1 }; obj.nonExistent default obj.anotherNonExistent default obj.a").value ==> 1
+    }
+  }
+}


### PR DESCRIPTION
This is the initial prototyping of the "default" operator. I think I still prefer it to the "?"-like syntax - or at least I think we should provide this as an option. This works pretty much like try/catch - the left hand expression is evaluated, but if it throws an error, the right hand is evaluated.

I'm still not 100% sure about the operator precedence though, it's something we need to discuss.
